### PR TITLE
fix typo, 出数学部分->除数学部分

### DIFF
--- a/source/fduthesis.dtx
+++ b/source/fduthesis.dtx
@@ -3425,7 +3425,7 @@ Copyright (C) 2017&ndash;2020 by Xiangdong Zeng <xdzeng96@gmail.com>.
 % \end{macro}
 %
 % \begin{macro}{\@@_load_font_times*:}
-% Times* 系列，出数学部分外采用系统字体。
+% Times* 系列，除数学部分外采用系统字体。
 %    \begin{macrocode}
 \cs_new_protected:cpn { @@_load_font_ times* : }
   {


### PR DESCRIPTION
订正一个错别字

因为想给 https://github.com/TheNetAdmin/zjuthesis/issues/73 回复，来这里查 fduthesis 的字体配置，偶然发现一个错别字。