### PR TITLE
修复对 `\addbibresource` 命令的支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,4 +163,4 @@ This work may be distributed and/or modified under the conditions of the [LaTeX 
 
 -----
 
-Copyright (C) 2017&ndash;2021 by Xiangdong Zeng.
+Copyright (C) 2017&ndash;2022 by Xiangdong Zeng.

--- a/docs/fduthesis-template.tex
+++ b/docs/fduthesis-template.tex
@@ -1,6 +1,6 @@
 % \iffalse meta-comment
 %
-% Copyright (C) 2017--2021 by Xiangdong Zeng <xdzeng96@gmail.com>
+% Copyright (C) 2017--2022 by Xiangdong Zeng <xdzeng96@gmail.com>
 %
 % This work may be distributed and/or modified under the
 % conditions of the LaTeX Project Public License, either

--- a/source/fduthesis-doc.dtx
+++ b/source/fduthesis-doc.dtx
@@ -1,6 +1,6 @@
 % \iffalse meta-comment
 %
-% Copyright (C) 2017--2021 by Xiangdong Zeng <xdzeng96@gmail.com>
+% Copyright (C) 2017--2022 by Xiangdong Zeng <xdzeng96@gmail.com>
 %
 % This work may be distributed and/or modified under the
 % conditions of the LaTeX Project Public License, either

--- a/source/fduthesis-logo.dtx
+++ b/source/fduthesis-logo.dtx
@@ -1,6 +1,6 @@
 % \iffalse meta-comment
 %
-% Copyright (C) 2017--2021 by Xiangdong Zeng <xdzeng96@gmail.com>
+% Copyright (C) 2017--2022 by Xiangdong Zeng <xdzeng96@gmail.com>
 %
 % This work may be distributed and/or modified under the
 % conditions of the LaTeX Project Public License, either

--- a/source/fduthesis.dtx
+++ b/source/fduthesis.dtx
@@ -2,7 +2,7 @@
 % !TeX program  = XeLaTeX
 % !TeX encoding = UTF-8
 %
-% Copyright (C) 2017--2021 by Xiangdong Zeng <xdzeng96@gmail.com>
+% Copyright (C) 2017--2022 by Xiangdong Zeng <xdzeng96@gmail.com>
 %
 % This work may be distributed and/or modified under the
 % conditions of the LaTeX Project Public License, either
@@ -124,7 +124,7 @@ version.
 
 -----
 
-Copyright (C) 2017&ndash;2021 by Xiangdong Zeng <xdzeng96@gmail.com>.
+Copyright (C) 2017&ndash;2022 by Xiangdong Zeng <xdzeng96@gmail.com>.
 %</readme>
 %
 %<*internal>
@@ -142,7 +142,7 @@ Copyright (C) 2017&ndash;2021 by Xiangdong Zeng <xdzeng96@gmail.com>.
 
 \preamble
 
-    Copyright (C) 2017--2021 by Xiangdong Zeng <xdzeng96@gmail.com>
+    Copyright (C) 2017--2022 by Xiangdong Zeng <xdzeng96@gmail.com>
 
     This work may be distributed and/or modified under the
     conditions of the LaTeX Project Public License, either
@@ -5797,11 +5797,23 @@ Copyright (C) 2017&ndash;2021 by Xiangdong Zeng <xdzeng96@gmail.com>.
 %    \end{macrocode}
 % \end{macro}
 %
+% \changes{v0.8}{2022/01/08}{兼容 \tn{addbibresource} 命令。}
+%
+% 由于 \pkg{biblatex} 在导言区后才载入，需要单独定义添加参考文献数据源的命令以实现兼容。该命令需要在载入宏包前取消定义。
+%    \begin{macrocode}
+\bool_if:NF \l_@@_bibtex_bool
+  {
+    \NewDocumentCommand \addbibresource { m }
+      { \clist_gput_right:Nn \l_@@_bib_resource_clist {#1} }
+  }
+%    \end{macrocode}
+%
 % \begin{macro}{\@@_biblatex_pre_setup:,\@@_biblatex_post_setup:}
 % \pkg{biblatex} 相关设置。
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_biblatex_pre_setup:
   {
+    \cs_undefine:N \addbibresource
     \clist_new:N \l_@@_biblatex_options_clist
     \clist_put_right:Nn \l_@@_biblatex_options_clist { hyperref = manual }
 %    \end{macrocode}


### PR DESCRIPTION
由于 `biblatex` 宏包是在在导言区后载入的，为了保持使用体验同普通载入方式一致，特别定义了一个可以在导言区使用的 `\addbibresource` 命令。

> 本来想解决 https://github.com/stone-zeng/fduthesis/issues/47 的问题，但走歪了……

另：新年快乐！顺手推进了一下版权日期。