### PR TITLE
Fix inconsistent local/global assignment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       SET_PATH: export PATH=/tmp/texlive/bin/x86_64-linux:$PATH
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install TeX Live
       run: |
         ${{ env.SET_PATH }}
@@ -50,7 +50,7 @@ jobs:
     env:
       SET_PATH: export PATH=/tmp/texlive/bin/universal-darwin:$PATH
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install TeX Live
       run: |
         ${{ env.SET_PATH }}
@@ -79,7 +79,7 @@ jobs:
     env:
       SET_PATH: ${env:PATH} = "${{ github.workspace }}\tmp\texlive\bin\windows;" + ${env:PATH}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install TeX Live
       run: |
         ${{ env.SET_PATH }}

--- a/source/fduthesis.dtx
+++ b/source/fduthesis.dtx
@@ -3008,11 +3008,11 @@ Copyright (C) 2017&ndash;2023 by Xiangdong Zeng <xdzeng96@gmail.com>.
     draft .choice:,
     draft / true  .code:n =
       {
-        \bool_set_true:N     \g_@@_draft_bool
+        \bool_gset_true:N    \g_@@_draft_bool
         \clist_gput_right:Nn \g_@@_to_ctexbook_clist { draft }
       },
     draft / false .code:n =
-      { \bool_set_false:N    \g_@@_draft_bool },
+      { \bool_gset_false:N   \g_@@_draft_bool },
     draft .default:n = true,
     draft .initial:n = false,
 %    \end{macrocode}

--- a/source/fduthesis.dtx
+++ b/source/fduthesis.dtx
@@ -3999,10 +3999,11 @@ Copyright (C) 2017&ndash;2023 by Xiangdong Zeng <xdzeng96@gmail.com>.
       }
 %    \end{macrocode}
 % \changes{v0.6}{2017/11/12}{不再依赖 XITS-Math 字体。}
+% \changes{v0.9b}{2024/03/20}{局部修改 \cs{l_@@_fn_style_tl}。}
 % 若使用 \opt{pifont} 类型，则需引入 \pkg{pifont} 宏包。
 %    \begin{macrocode}
       {
-        \tl_gset_eq:NN \l_@@_fn_style_tl \l_keys_choice_tl
+        \tl_set_eq:NN \l_@@_fn_style_tl \l_keys_choice_tl
         \int_compare:nT { 5 <= \l_keys_choice_int <= 8 }
           { \RequirePackage { pifont } }
       },

--- a/source/fduthesis.dtx
+++ b/source/fduthesis.dtx
@@ -4894,7 +4894,7 @@ Copyright (C) 2017&ndash;2023 by Xiangdong Zeng <xdzeng96@gmail.com>.
       \clist_clear:N \l_@@_tmpa_clist
       \clist_map_inline:nn { department, major, author, supervisor, date }
         {
-          \clist_gput_right:Nn \l_@@_tmpa_clist
+          \clist_put_right:Nn \l_@@_tmpa_clist
             {
               \exp_args:Nx \@@_cover_info_left:n
                 { \tl_use:c { c_@@_name_ ##1 _tl } }

--- a/source/fduthesis.dtx
+++ b/source/fduthesis.dtx
@@ -2970,12 +2970,13 @@ Copyright (C) 2017&ndash;2023 by Xiangdong Zeng <xdzeng96@gmail.com>.
 % \changes{v0.7}{2018/02/01}{新增 \opt{type} 选项。}
 %
 % \begin{macro}{type}
+% \changes{v0.9b}{2024/03/20}{全局设置 \cs{g_@@_thesis_type_tl}。}
 % 设置论文类型。设为模板选项主要是为了以后的兼容性。论文类型可能会
 % 影响很多设置，只是暂时还不考虑。默认为本科毕业论文。
 %    \begin{macrocode}
     type .choices:nn =
       { doctor, master, bachelor }
-      { \tl_set_eq:NN \g_@@_thesis_type_tl \l_keys_choice_tl },
+      { \tl_gset_eq:NN \g_@@_thesis_type_tl \l_keys_choice_tl },
     type .value_required:n = true,
     type .initial:n = bachelor,
 %    \end{macrocode}

--- a/source/fduthesis.dtx
+++ b/source/fduthesis.dtx
@@ -3186,7 +3186,7 @@ Copyright (C) 2017&ndash;2023 by Xiangdong Zeng <xdzeng96@gmail.com>.
   {
     font .choices:nn =
       { garamond, libertinus, lm, palatino, times, times*, none }
-      { \tl_set_eq:NN \g_@@_fontset_tl \l_keys_choice_tl },
+      { \tl_gset_eq:NN \g_@@_fontset_tl \l_keys_choice_tl },
     font .value_required:n = true,
   }
 %    \end{macrocode}

--- a/source/fduthesis.dtx
+++ b/source/fduthesis.dtx
@@ -3023,7 +3023,7 @@ Copyright (C) 2017&ndash;2023 by Xiangdong Zeng <xdzeng96@gmail.com>.
 % \begin{macro}{config}
 % 配置文件名。
 %    \begin{macrocode}
-    config .tl_set:N = \g_@@_config_tl,
+    config .tl_gset:N = \g_@@_config_tl,
 %    \end{macrocode}
 % \end{macro}
 %

--- a/source/fduthesis.dtx
+++ b/source/fduthesis.dtx
@@ -2809,7 +2809,7 @@ Copyright (C) 2017&ndash;2023 by Xiangdong Zeng <xdzeng96@gmail.com>.
 % 是否开启双页模式（默认打开）。
 %    \begin{macrocode}
 \bool_new:N \g_@@_twoside_bool
-\bool_set_true:N \g_@@_twoside_bool
+\bool_gset_true:N \g_@@_twoside_bool
 %    \end{macrocode}
 % \end{variable}
 %
@@ -2990,12 +2990,12 @@ Copyright (C) 2017&ndash;2023 by Xiangdong Zeng <xdzeng96@gmail.com>.
     oneside .code:n =
       {
         \clist_gput_right:Nn \g_@@_to_ctexbook_clist { oneside }
-        \bool_set_false:N    \g_@@_twoside_bool
+        \bool_gset_false:N   \g_@@_twoside_bool
       },
     twoside .code:n =
       {
         \clist_gput_right:Nn \g_@@_to_ctexbook_clist { twoside }
-        \bool_set_true:N     \g_@@_twoside_bool
+        \bool_gset_true:N    \g_@@_twoside_bool
       },
 %    \end{macrocode}
 % \end{macro}

--- a/source/fduthesis.dtx
+++ b/source/fduthesis.dtx
@@ -3201,7 +3201,7 @@ Copyright (C) 2017&ndash;2023 by Xiangdong Zeng <xdzeng96@gmail.com>.
   {
     cjk-font .choices:nn =
       { adobe, fandol, founder, mac, sinotype, sourcehan, windows, none }
-      { \tl_set_eq:NN \g_@@_cjk_fontset_tl \l_keys_choice_tl },
+      { \tl_gset_eq:NN \g_@@_cjk_fontset_tl \l_keys_choice_tl },
     cjk-font .value_required:n = true,
   }
 %    \end{macrocode}

--- a/testfiles/01-internal.luatex.tlg
+++ b/testfiles/01-internal.luatex.tlg
@@ -206,10 +206,10 @@ l. ...  }
 <argument> \l_tmpa_box 
 l. ...  }
 > \box...=
-\hbox(7.16646+1.14459)x142.26378, direction TLT
+\hbox(7.16678+1.14427)x142.26378, direction TLT
 .\whatsit4=[]
 .\mathon
-.\vbox(7.16646+1.14459)x142.26378, direction TLT
+.\vbox(7.16678+1.14427)x142.26378, direction TLT
 ..\whatsit4=[]
 ..\vbox(8.14243+0.16862)x142.26378, direction TLT
 ...\whatsit4=[]
@@ -233,10 +233,10 @@ l. ...  }
 <argument> \l_tmpa_box 
 l. ...  }
 > \box...=
-\hbox(9.03343+3.01157)x142.26378, direction TLT
+\hbox(9.03375+3.01125)x142.26378, direction TLT
 .\whatsit4=[]
 .\mathon
-.\vbox(9.03343+3.01157)x142.26378, direction TLT
+.\vbox(9.03375+3.01125)x142.26378, direction TLT
 ..\whatsit4=[]
 ..\vbox(10.5996+1.4454)x142.26378, direction TLT
 ...\whatsit4=[]
@@ -268,10 +268,10 @@ l. ...  }
 <argument> \l_tmpa_box 
 l. ...  }
 > \box...=
-\hbox(7.16646+1.14459)x142.26378, direction TLT
+\hbox(7.16678+1.14427)x142.26378, direction TLT
 .\whatsit4=[]
 .\mathon
-.\vbox(7.16646+1.14459)x142.26378, direction TLT
+.\vbox(7.16678+1.14427)x142.26378, direction TLT
 ..\whatsit4=[]
 ..\vbox(8.14243+0.16862)x142.26378, direction TLT
 ...\whatsit4=[]
@@ -296,10 +296,10 @@ l. ...  }
 <argument> \l_tmpa_box 
 l. ...  }
 > \box...=
-\hbox(9.03343+3.01157)x142.26378, direction TLT
+\hbox(9.03375+3.01125)x142.26378, direction TLT
 .\whatsit4=[]
 .\mathon
-.\vbox(9.03343+3.01157)x142.26378, direction TLT
+.\vbox(9.03375+3.01125)x142.26378, direction TLT
 ..\whatsit4=[]
 ..\vbox(10.5996+1.4454)x142.26378, direction TLT
 ...\whatsit4=[]
@@ -378,10 +378,10 @@ l. ...  }
 TEST 3: Boxes in thesis cover (underfull)
 ============================================================
 > \box...=
-\hbox(19.0334+13.01155)x56.9055, direction TLT
+\hbox(19.03372+13.01123)x56.9055, direction TLT
 .\whatsit4=[]
 .\mathon
-.\vbox(19.0334+13.01155)x56.9055, direction TLT
+.\vbox(19.03372+13.01123)x56.9055, direction TLT
 ..\whatsit4=[]
 ..\vbox(30.59955+1.4454)x56.9055, direction TLT
 ...\whatsit4=[]
@@ -423,10 +423,10 @@ TEST 3: Boxes in thesis cover (underfull)
 <argument> \l_tmpa_box 
 l. ...  }
 > \box...=
-\hbox(19.0334+13.01155)x56.9055, direction TLT
+\hbox(19.03372+13.01123)x56.9055, direction TLT
 .\whatsit4=[]
 .\mathon
-.\vbox(19.0334+13.01155)x56.9055, direction TLT
+.\vbox(19.03372+13.01123)x56.9055, direction TLT
 ..\whatsit4=[]
 ..\vbox(30.59955+1.4454)x56.9055, direction TLT
 ...\whatsit4=[]

--- a/testfiles/03-basic-en.luatex.tlg
+++ b/testfiles/03-basic-en.luatex.tlg
@@ -658,7 +658,7 @@ Completed box being shipped out [3]
 ........\TU/XITS(0)/m/n/12.045 o
 ........\TU/XITS(0)/m/n/12.045 n
 ........\glue(\spaceskip) 3.01125 plus 1.50563 minus 1.00375
-........\TU/XITS(0)/m/n/12.045 — (ligature ---)
+........\TU/XITS(0)/m/n/12.045 —
 ........\glue(\spaceskip) 3.01125 plus 1.50563 minus 1.00375
 ........\TU/XITS(0)/m/n/12.045 b
 ........\TU/XITS(0)/m/n/12.045 r
@@ -724,7 +724,7 @@ Completed box being shipped out [3]
 ........\TU/XITS(0)/m/n/12.045 o
 ........\TU/XITS(0)/m/n/12.045 n
 ........\glue(\spaceskip) 3.01125 plus 1.50563 minus 1.00375
-........\TU/XITS(0)/m/n/12.045 — (ligature ---)
+........\TU/XITS(0)/m/n/12.045 —
 ........\glue(\spaceskip) 3.01125 plus 1.50563 minus 1.00375
 ........\TU/XITS(0)/m/n/12.045 k
 ........\kern-0.15659 (font)

--- a/testfiles/04-cover.luatex.tlg
+++ b/testfiles/04-cover.luatex.tlg
@@ -109,7 +109,7 @@ Completed box being shipped out [1]
 .....\pdfcolorstack 0 pop
 ...\glue 19.8738
 ...\glue(\lineskip) 0.0
-...\vbox(700.50723+0.0)x416.54877, glue set 24.7012fill, direction TLT
+...\vbox(700.50723+0.0)x416.54877, glue set 24.70126fill, direction TLT
 ....\whatsit4=[]
 ....\glue(\topskip) 12.0
 ....\rule(0.0+0.0)x*
@@ -121,7 +121,7 @@ Completed box being shipped out [1]
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\lineskip) 1.0
-....\hbox(17.25812+12.74173)x416.54877, glue set 320.21127fil, direction TLT
+....\hbox(17.25836+12.74149)x416.54877, glue set 320.21127fil, direction TLT
 .....\whatsit4=[]
 .....\glue(\leftskip) 0.0 plus 1.0fil
 .....\localpar
@@ -140,10 +140,10 @@ Completed box being shipped out [1]
 .......\pdfcolorstack 0 pop
 ......\glue 6.0
 .....\penalty 0
-.....\hbox(17.25812+12.74173)x96.3375, direction TLT
+.....\hbox(17.25836+12.74149)x96.3375, direction TLT
 ......\whatsit4=[]
 ......\mathon
-......\vbox(17.25812+12.74173)x96.3375, direction TLT
+......\vbox(17.25836+12.74149)x96.3375, direction TLT
 .......\whatsit4=[]
 .......\vbox(25.49983+4.50002)x96.3375, direction TLT
 ........\whatsit4=[]
@@ -365,8 +365,8 @@ Completed box being shipped out [1]
 ....\glue 13.0 plus 7.0 minus 8.0
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
-....\glue(\baselineskip) 16.44978
-....\hbox(13.55014+4.51735)x416.54877, glue set 20.82872fil, direction TLT
+....\glue(\baselineskip) 16.4493
+....\hbox(13.55063+4.51686)x416.54877, glue set 20.82872fil, direction TLT
 .....\whatsit4=[]
 .....\glue(\leftskip) 0.0 plus 1.0fil
 .....\localpar
@@ -386,7 +386,7 @@ Completed box being shipped out [1]
 ......\glue 6.0
 .....\penalty 0
 .....\mathon
-.....\vbox(13.55014+4.51735)x374.89134, direction TLT
+.....\vbox(13.55063+4.51686)x374.89134, direction TLT
 ......\whatsit4=[]
 ......\vbox(15.89938+2.1681)x374.89134, direction TLT
 .......\whatsit4=[]
@@ -440,8 +440,8 @@ Completed box being shipped out [1]
 ....\glue 13.0 plus 7.0 minus 8.0
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
-....\glue(\baselineskip) 7.25194
-....\hbox(8.46625+1.44075)x416.54877, glue set 20.82872fil, direction TLT
+....\glue(\baselineskip) 7.25204
+....\hbox(8.46663+1.44037)x416.54877, glue set 20.82872fil, direction TLT
 .....\whatsit4=[]
 .....\glue(\leftskip) 0.0 plus 1.0fil
 .....\localpar
@@ -461,7 +461,7 @@ Completed box being shipped out [1]
 ......\glue 6.0
 .....\penalty 0
 .....\mathon
-.....\vbox(8.46625+1.44075)x374.89134, direction TLT
+.....\vbox(8.46663+1.44037)x374.89134, direction TLT
 ......\whatsit4=[]
 ......\vbox(9.71027+0.19673)x374.89134, direction TLT
 .......\whatsit4=[]
@@ -519,7 +519,7 @@ Completed box being shipped out [1]
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\lineskip) 1.0
-....\hbox(74.49312+67.46764)x416.54877, glue set 105.6635fil, direction TLT
+....\hbox(74.4935+67.46725)x416.54877, glue set 105.6635fil, direction TLT
 .....\whatsit4=[]
 .....\glue(\leftskip) 0.0 plus 1.0fil
 .....\localpar
@@ -538,10 +538,10 @@ Completed box being shipped out [1]
 .......\pdfcolorstack 0 pop
 ......\glue 6.0
 .....\penalty 0
-.....\hbox(74.49312+67.46764)x205.22177, direction TLT
+.....\hbox(74.4935+67.46725)x205.22177, direction TLT
 ......\whatsit4=[]
 ......\mathon
-......\vbox(74.49312+67.46764)x205.22177, direction TLT
+......\vbox(74.4935+67.46725)x205.22177, direction TLT
 .......\whatsit4=[]
 .......\vbox(134.96071+7.00005)x205.22177, direction TLT
 ........\whatsit4=[]

--- a/testfiles/support/fduthesis-regression-test.tex
+++ b/testfiles/support/fduthesis-regression-test.tex
@@ -2,7 +2,9 @@
 
 \input{regression-test}
 
-\RequirePackage{expl3}
+\ExplSyntaxOn
+\debug_on:n { check-declarations }
+\ExplSyntaxOff
 
 \def\MAKECOVERFALSE{%
   \fdusetup{style/auto-make-cover = false}}


### PR DESCRIPTION
Fixes #329.

目前，前两个提交是与主题无关的，一个是为了让 `l3build check` 通过，一个是维护性工作。我想等 #330 解决后，rebase 并 squash 提交。

在解决 inconsistent local/global assignment 报错时，我选择了「总是遵照变量命名里的 `l/g` 而改动对变量赋值的函数」。

在 `fduthesis-regression-test.tex` 为所有测试设置 `\debug_on:n { check-declarations }`，虽然现在能通过 CI，但这有赖于目前的测试覆盖不完整、没有大量使用 `ctex` 功能。实际上 `ctex/xecjk` 本身目前通不过 `check-declarations`。

```tex
% !TeX program = xelatex
\ExplSyntaxOn
\debug_on:n { check-declarations }
\ExplSyntaxOff
\documentclass{ctexart}

\begin{document}
\end{document}
```